### PR TITLE
feat: Substitui confirm por modal personalizado

### DIFF
--- a/renderer.js
+++ b/renderer.js
@@ -2027,12 +2027,13 @@ function closeTemplateModal() {
 }
 
 // Criar projeto a partir de template
-function createProjectFromTemplate(templateId) {
+async function createProjectFromTemplate(templateId) {
     const template = projectTemplates.find(t => t.id === templateId);
     if (!template) return;
     
     if (currentProject || document.querySelectorAll('.designer-component').length > 0 || Object.keys(projectVariables).length > 0) {
-        if (!confirm('Criar novo projeto? Todas as alterações não salvas serão perdidas.')) {
+        const confirmed = await showCustomConfirm('Criar Novo Projeto', 'Todas as alterações não salvas serão perdidas. Deseja continuar?');
+        if (!confirmed) {
             return;
         }
     }


### PR DESCRIPTION
Substituí a função `confirm` do navegador por um modal de confirmação personalizado ao criar um novo projeto ou selecionar um template. Isso melhora a sua experiência e a consistência da interface.