### PR TITLE
Fix: Component spacing incorrect after editor zoom

### DIFF
--- a/renderer.js
+++ b/renderer.js
@@ -2574,11 +2574,10 @@ function generateHTML() {
     
     components.forEach(component => {
         const element = component.firstElementChild;
-        const rect = component.getBoundingClientRect();
-        const canvasRect = canvas.getBoundingClientRect();
         
-        const x = rect.left - canvasRect.left;
-        const y = rect.top - canvasRect.top;
+        // Usar style.left e style.top para obter a posição não escalonada
+        const x = parseInt(component.style.left) || 0;
+        const y = parseInt(component.style.top) || 0;
         
         // Clonar elemento e adicionar posicionamento
         const clone = element.cloneNode(true);


### PR DESCRIPTION
The `generateHTML` function was using `getBoundingClientRect` to determine component positions for the runtime preview. This method returns values affected by CSS transforms, causing the component spacing to be incorrect when the editor was zoomed in or out.

This change modifies `generateHTML` to use `component.style.left` and `component.style.top` instead. These properties store the unscaled layout positions, ensuring that the generated code is independent of the editor's zoom level.