### PR TITLE
Fix: Style editor not loading saved values for actions

### DIFF
--- a/renderer.js
+++ b/renderer.js
@@ -2025,9 +2025,10 @@ function updateActionParameters(valueToSet = null) {
     switch (actionType) {
         case 'change_style':
             const targetId = document.getElementById('target-element').value;
+            const escapedValueToSet = (valueToSet || '{}').replace(/"/g, '&quot;');
             parametersHTML = `
                 <label style="display: block; margin-bottom: 5px; font-weight: bold;">Estilos a serem alterados:</label>
-                <input type="hidden" id="action-value" value="${valueToSet || '{}'}">
+                <input type="hidden" id="action-value" value="${escapedValueToSet}">
                 <button type="button" id="open-style-editor" class="btn primary" style="width: 100%; padding: 8px;">Abrir Editor de Estilo</button>
                 <div id="style-preview" style="margin-top: 10px; font-size: 12px; color: #9d9d9d; max-height: 50px; overflow-y: auto;">...</div>
             `;


### PR DESCRIPTION
The style editor for 'Change Style' actions was not correctly loading previously saved styles. This was due to a bug where the JSON string containing the style data was not being properly escaped when set as the `value` attribute of a hidden input. This caused the HTML to be malformed, leading to a failure in parsing the JSON data.

This commit fixes the issue by escaping the double quotes in the JSON string before setting it as the input's value attribute. This ensures the data is preserved correctly and the style editor now loads the saved values as expected.