### PR TITLE
Movimentação e Seleção de componentes melhorados

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -1378,3 +1378,28 @@ button[style*="font-size: 12px"]:hover {
     background: none;
     cursor: pointer;
 }
+
+.designer-component .move-handle {
+    position: absolute;
+    width: 20px;
+    height: 20px;
+    background-color: #007acc;
+    border: 1px solid #ffffff;
+    left: 50%;
+    bottom: -30px;
+    transform: translateX(-50%);
+    cursor: move;
+    opacity: 0;
+    transition: opacity 0.2s ease;
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 12px;
+    color: white;
+    z-index: 10;
+}
+
+.designer-component.selected .move-handle {
+    opacity: 1;
+}


### PR DESCRIPTION
This commit introduces a dedicated move handle for components in the visual designer. This improves the user experience by making the move action explicit and predictable.

Key changes:
- A new `move-handle` element is added to each component when it's created.
- The move handle is styled to be a small circle positioned below the component, and it only appears when the component is selected.
- The drag-to-move logic has been moved from the main component body to the new move handle. This means components are now moved exclusively by dragging this handle.
- The previous component drag logic on the wrapper has been removed to avoid conflicting behaviors.

This change also supports the previous fix for component selection, as making the entire component body selectable required a dedicated way to handle movement.